### PR TITLE
Update normalize.R

### DIFF
--- a/R/normalize.R
+++ b/R/normalize.R
@@ -1,12 +1,19 @@
 #' Perform Probabilistic Quotient Normalization for intensities.
 #'
+#' Perform Probabilistic Quotient Normalization (PQN) for sample intensities.
+#' The PQN method determines a dilution factor for each sample by comparing
+#' the distibution of quotients between samples and a reference spectrum, followed
+#' by sample normalization using this dilution factor.
+#' The reference spectrum in this method is the average lipid abundance of all 
+#' samples (exluding blanks).
+#'
 #' @param data Skyline data.frame created by \code{\link{read_skyline}}
-#' @param measure which measure to use as intensity, usually Area, Area.Normalized or Height
+#' @param measure Which measure to use as intensity, usually Area, Area.Normalized or Height
 #' @param exclude Samples to exclude, can be either: \cr 
 #' "blank" - automatically detected blank samples and exclude them
 #' logical vector with the same length as samples
 #' 
-#' @param log whether the normalized values should be log2 transformed
+#' @param log Whether the normalized values should be log2 transformed
 #'
 #' @return
 #' @importFrom SummarizedExperiment assay<- assays<-
@@ -45,6 +52,11 @@ normalize_pqn <- function(data, measure="Area", exclude="blank", log=TRUE) {
 }
 
 #' Normalize each class by its corresponding internal standard(s).
+#'
+#' Normalize each class by its corresponding internal standard(s).
+#' Lipid classes are normalized using corresponding internal standard(s)
+#' of the same lipid class. If no corresponding internal standard is found
+#' the average of all measured internal standards is used instead.
 #'
 #' @param data Skyline data.frame created by \code{\link{read_skyline}}
 #' @param measure which measure to use as intensity, usually Area, Area.Normalized or Height


### PR DESCRIPTION
Change param log to log2?
How are internal standards picked? Are they corrected per class or by mean ITSD abundance?
Is my description correct that the average ITSD is used if no corresponding ITSD is found.

Maybe we should change itsd to istd, which seems to be more commonly used.